### PR TITLE
Fix transposition of configurable crlf and return characters

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -9,12 +9,12 @@ function activate(context) {
     const decorationColor = configuration.color
     // get characters at start
     const newline_char = configuration.newlineCharacter ? configuration.newlineCharacter : '↓'
-    const return_char  = configuration.returnCharacter  ? configuration.returnCharacter  : '↵'
-    const crlf_char    = configuration.crlfCharacter    ? configuration.crlfCharacter    : '←'
+    const return_char  = configuration.returnCharacter  ? configuration.returnCharacter  : '←'
+    const crlf_char    = configuration.crlfCharacter    ? configuration.crlfCharacter    : '↵'
     // init some vars outside of updateDecorations for efficiency
     const render_newline = { after: { contentText: newline_char, color: decorationColor } }
-    const render_crlf    = { after: { contentText: return_char, color : decorationColor } }
-    const render_return  = { after: { contentText: crlf_char, color   : decorationColor } }
+    const render_return  = { after: { contentText: return_char, color : decorationColor } }
+    const render_crlf    = { after: { contentText: crlf_char, color   : decorationColor } }
     const render_blank   = { after: { contentText: '', color          : decorationColor } }
     var match
     var the_render_option


### PR DESCRIPTION
Previously the "code-eol.returnCharacter" setting would actually provide the character that was displayed for CRLF line endings. This changes it so that the "code-eol.crlfCharacter" setting controls it instead (as would be expected), but also maintains the default characters that were previously shown for all line ending types.
